### PR TITLE
Mandrill logs and export batch

### DIFF
--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -192,6 +192,7 @@ class PanoplyMandrill(panoply.DataSource):
             if (status == 'error' or status == 'expired'):
                 self.log('WARN: export job status was:', status);
                 return False
+            self.log('waiting for export job to finish')
             time.sleep(SLEEP_TIME_SECONDS)
 
         while url is None:

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -23,7 +23,7 @@ SLEEP_TIME_SECONDS = 20
 COPY_CHUNK_SIZE = 16 * 1024
 CSV_FILE_NAME = "activity.csv"
 EXTRACTED_FIELDS_BATCH_SIZE = 50
-EXPORT_BATCH_SIZE = 1000
+EXPORT_BATCH_SIZE = 3000
 
 def mergeDicts(x, y):
     '''Given two dicts, merge them into a new dict as a shallow copy.'''
@@ -225,7 +225,7 @@ class PanoplyMandrill(panoply.DataSource):
             'results': results,
             'function': self.staggerExport
         }
-        # will periodically process the extracted fields
+        # will periodically return part of the result set
         self.setOngoingJob(data)
         # return the 1st batch
         return self.staggerExport(data)
@@ -247,6 +247,3 @@ class PanoplyMandrill(panoply.DataSource):
         self.setOngoingJob(data)
         self.log('sending export batch #%d' % batch_number)
         return results
-        
-
-

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -23,7 +23,7 @@ SLEEP_TIME_SECONDS = 20
 COPY_CHUNK_SIZE = 16 * 1024
 CSV_FILE_NAME = "activity.csv"
 EXTRACTED_FIELDS_BATCH_SIZE = 50
-EXPORT_BATCH_SIZE = 3000
+EXPORT_BATCH_SIZE = 1000
 
 def mergeDicts(x, y):
     '''Given two dicts, merge them into a new dict as a shallow copy.'''

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -6,6 +6,7 @@ import tempfile
 import shutil
 import zipfile
 import csv
+import os
 from datetime import datetime
 from functools import partial, wraps
 from itertools import chain
@@ -209,14 +210,14 @@ class PanoplyMandrill(panoply.DataSource):
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
-            self.log('download has finished')
+            self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)
             csv_reader = csv.DictReader(zf.open(CSV_FILE_NAME), delimiter=',')
             self.log('zipfile has been retrieved, unzipping as a stream')
             for row in csv_reader:
                 results.append(row)
                 log_counter += 1
-                if log_counter % 2 == 0:
+                if log_counter % 100 == 0:
                     self.log('processed %d lines so far' % log_counter)
         finally:
             tmp_file.close()

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -217,7 +217,7 @@ class PanoplyMandrill(panoply.DataSource):
                 results.append(row)
                 log_counter += 1
                 if log_counter % 200 == 0:
-                    self.log('proccessed %d lines so far' % log_counter)
+                    self.log('processed %d lines so far' % log_counter)
         finally:
             tmp_file.close()
         return results

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -201,15 +201,22 @@ class PanoplyMandrill(panoply.DataSource):
             return []
         
         # now we have the url to download from
+        self.log('starting to download from:', url)
         req = urlopen(url)
         results = []
+        log_counter = 0
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
+            self.log('download has finished')
             zf = zipfile.ZipFile(tmp_file)
             csv_reader = csv.DictReader(zf.open(CSV_FILE_NAME), delimiter=',')
+            self.log('zipfile has been retrieved, unzipping as a stream')
             for row in csv_reader:
                 results.append(row)
+                log_counter += 1
+                if log_counter % 200 == 0:
+                    self.log('proccessed %d lines so far' % log_counter)
         finally:
             tmp_file.close()
         return results

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -242,7 +242,7 @@ class PanoplyMandrill(panoply.DataSource):
             self.stopOngoingJob()
             return []
         # reduce the batch for the next callable
-        data['results'] = data.get('results', [])[EXTRACTED_FIELDS_BATCH_SIZE:]
+        data['results'] = data.get('results', [])[EXPORT_BATCH_SIZE:]
         data['batch_number'] = batch_number + 1
         self.setOngoingJob(data)
         self.log('sending export batch #%d' % batch_number)

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -216,7 +216,7 @@ class PanoplyMandrill(panoply.DataSource):
             for row in csv_reader:
                 results.append(row)
                 log_counter += 1
-                if log_counter % 200 == 0:
+                if log_counter % 2 == 0:
                     self.log('processed %d lines so far' % log_counter)
         finally:
             tmp_file.close()


### PR DESCRIPTION
Added logs to the export process in Mandrill.

Also changed the export call to send the results in batches of 1k rows (it sent 389k rows at once at the start).
The problem was not the memory usage(since it won't help in that regard), the problem was that the writer couldn't handle such a big batch and would hang or act irrationally.

@alonweissfeld  thanks