### PR TITLE
mark the invalid key error as non retryable

### DIFF
--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -10,7 +10,7 @@ import os
 from datetime import datetime
 from functools import partial, wraps
 from itertools import chain
-from mandrill import Mandrill
+from mandrill import Mandrill, InvalidKeyError
 from urllib2 import urlopen
 
 MINUTE = 60
@@ -62,7 +62,11 @@ class PanoplyMandrill(panoply.DataSource):
         self.ongoingJob = None
         self.mandrill_client = Mandrill(self.key)
         # will raise InvalidKeyError if the api key is wrong
-        self.mandrill_client.users.ping()
+        try:
+            self.mandrill_client.users.ping()
+        except InvalidKeyError as e:
+            e.retryable = False
+            raise e
 
     def getLastTimeSucceed(self, source):
         '''if lastTimeSucceed exists, use it as fromTime'''


### PR DESCRIPTION
Demonstrate a way to use the new `retryable` flag on the Python exceptions.
(PR on main repo: https://github.com/avinoamr/color/pull/939)

Here I add the `retryable = False` on the `InvalidKeyError`, there are more ways to utilize it (could monkey patch the `InvalidKeyError` exception itself too).

On user defined errors (in opposed to sdk ones) it should be ok to set the `retryable` flag on the exception class itself although for greater flexibility you can dynamically add the flag when needed (like I did here)

@liorrozen thanks