### PR TITLE
Fix zombie bug step #1

### DIFF
--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -232,6 +232,7 @@ class PanoplyMandrill(panoply.DataSource):
         already_seen_map = defaultdict(lambda: 1)
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
+            raise Exception('This Is Madness')
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
             self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)
@@ -245,6 +246,8 @@ class PanoplyMandrill(panoply.DataSource):
                 row['id'] = key + '-' + str(already_seen_map[key])
                 already_seen_map[key] += 1
                 results.append(row)
+        except Exception, e:
+            raise e
         finally:
             tmp_file.close()
         

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -92,7 +92,7 @@ class PanoplyMandrill(panoply.DataSource):
         key += self.key + '-'
         for field in EXPORT_COUNTER_KEY_FIELDS:
             if field in row:
-                key += row[field].decode('utf-8')
+                key += row[field]
             key += '-'
         key = key[:-1] # remove the last '-'
         return key

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -92,7 +92,7 @@ class PanoplyMandrill(panoply.DataSource):
         key += self.key + '-'
         for field in EXPORT_COUNTER_KEY_FIELDS:
             if field in row:
-                key += row[field]
+                key += row[field].decode('utf-8')
             key += '-'
         key = key[:-1] # remove the last '-'
         return key

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -232,6 +232,7 @@ class PanoplyMandrill(panoply.DataSource):
         already_seen_map = defaultdict(lambda: 1)
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
+            raise Exception('ouch')
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
             self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)
@@ -248,6 +249,7 @@ class PanoplyMandrill(panoply.DataSource):
         except Exception, e:
             raise e
         finally:
+            self.log('TESTTHISTESTTESTTHISTEST')
             tmp_file.close()
         
         # stagger the results so the writer can handle them

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -232,7 +232,6 @@ class PanoplyMandrill(panoply.DataSource):
         already_seen_map = defaultdict(lambda: 1)
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
-            raise Exception('ouch')
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
             self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)
@@ -249,7 +248,6 @@ class PanoplyMandrill(panoply.DataSource):
         except Exception, e:
             raise e
         finally:
-            self.log('TESTTHISTESTTESTTHISTEST')
             tmp_file.close()
         
         # stagger the results so the writer can handle them

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -232,7 +232,6 @@ class PanoplyMandrill(panoply.DataSource):
         already_seen_map = defaultdict(lambda: 1)
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
-            raise Exception('This Is Madness')
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
             self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_mandrill",
-    version="1.0.3",
+    version="1.0.4",
     description="Panoply Data Source for Mandrill API",
     author="Kfir Gez, Oshri Bienhaker",
     author_email="kfir@panoply.io, oshri@panoply.io",


### PR DESCRIPTION
Task: https://app.asana.com/0/41101186914227/254644876537404
Step # 1 we raise the error from the `try` block.

This is very possibly the reason why the mandrill got stuck as zombie, it seems like it got an error in the `try` block but since we just had a `finally` it got swollen and stucked as zombie.

After we can see the error it will be easier to solve it (it only happens on production it may be due to the differences between encoding between mac/linux)