### PR TITLE
Fix zombie bug -> Better memory utilization

### DIFF
--- a/panoply_mandrill/conf.py
+++ b/panoply_mandrill/conf.py
@@ -1,4 +1,4 @@
-DAY_RANGE = 30 # The range of days to import data from
+DAY_RANGE = 7 # The range of days to import data from
 
 metrics = [
     {

--- a/panoply_mandrill/conf.py
+++ b/panoply_mandrill/conf.py
@@ -1,4 +1,4 @@
-DAY_RANGE = 7 # The range of days to import data from
+DAY_RANGE = 30 # The range of days to import data from
 
 metrics = [
     {

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -246,7 +246,7 @@ class PanoplyMandrill(panoply.DataSource):
             for row in csv_reader:
                 key = self.generateExportKey(row)
                 # final id form is the generated key + '-' + idrank
-                row['id'] = key + '-' + 1
+                row['id'] = key + '-' + str(1)
                 #already_seen_map[key] += 1
                 results.append(row)
         except Exception, e:

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -24,7 +24,7 @@ SLEEP_TIME_SECONDS = 20
 COPY_CHUNK_SIZE = 16 * 1024
 CSV_FILE_NAME = "activity.csv"
 EXTRACTED_FIELDS_BATCH_SIZE = 50
-EXPORT_BATCH_SIZE = 3000
+EXPORT_BATCH_SIZE = 1000
 # if a csv row has all(or some) of these fields equal, we will increase its idrank
 EXPORT_COUNTER_KEY_FIELDS = ['Date', 'Email Address', 'Sender', 'Subject']
 
@@ -233,7 +233,7 @@ class PanoplyMandrill(panoply.DataSource):
         req = urlopen(url)
         results = []
         # count how many times we have seen the given row
-        #already_seen_map = defaultdict(lambda: 1)
+        already_seen_map = defaultdict(lambda: 1)
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
@@ -242,12 +242,12 @@ class PanoplyMandrill(panoply.DataSource):
             csv_reader = csv.DictReader(zf.open(CSV_FILE_NAME), delimiter=',')
             self.log('zipfile has been retrieved, unzipping as a stream')
             # rankid the rows
-            #self.log('ranking the csv export rows')
+            self.log('ranking the csv export rows')
             for row in csv_reader:
                 key = self.generateExportKey(row)
                 # final id form is the generated key + '-' + idrank
-                row['id'] = key + '-' + str(1)
-                #already_seen_map[key] += 1
+                row['id'] = key + '-' + str(already_seen_map[key])
+                already_seen_map[key] += 1
                 results.append(row)
         except Exception, e:
             raise e

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -233,7 +233,7 @@ class PanoplyMandrill(panoply.DataSource):
         req = urlopen(url)
         results = []
         # count how many times we have seen the given row
-        already_seen_map = defaultdict(lambda: 1)
+        #already_seen_map = defaultdict(lambda: 1)
         tmp_file = tempfile.NamedTemporaryFile(delete=True)
         try:
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
@@ -242,12 +242,12 @@ class PanoplyMandrill(panoply.DataSource):
             csv_reader = csv.DictReader(zf.open(CSV_FILE_NAME), delimiter=',')
             self.log('zipfile has been retrieved, unzipping as a stream')
             # rankid the rows
-            self.log('ranking the csv export rows')
+            #self.log('ranking the csv export rows')
             for row in csv_reader:
                 key = self.generateExportKey(row)
                 # final id form is the generated key + '-' + idrank
-                row['id'] = key + '-' + str(already_seen_map[key])
-                already_seen_map[key] += 1
+                row['id'] = key + '-' + 1
+                #already_seen_map[key] += 1
                 results.append(row)
         except Exception, e:
             raise e

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -244,6 +244,8 @@ class PanoplyMandrill(panoply.DataSource):
             output = StringIO.StringIO()
             shutil.copyfileobj(zf.open(CSV_FILE_NAME), output, COPY_CHUNK_SIZE)
             zf.close()
+            # rewind the file-like memory object back to start
+            output.seek(0)
             csv_reader = csv.DictReader(output, delimiter=',')
             self.log('zipfile has been retrieved')
         except Exception, e:

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -240,9 +240,9 @@ class PanoplyMandrill(panoply.DataSource):
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
             self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)
-            mapped_file = mmap.mmap(zf.open(CSV_FILE_NAME).fileno(), 0, access=mmap.ACCESS_READ)
-            zf.close()
-            csv_reader = csv.DictReader(mapped_file, delimiter=',')
+            #mapped_file = mmap.mmap(zf.open(CSV_FILE_NAME).fileno(), 0, access=mmap.ACCESS_READ)
+            #zf.close()
+            csv_reader = csv.DictReader(zf.open(CSV_FILE_NAME), delimiter=',')
             self.log('zipfile has been retrieved')
         except Exception, e:
             raise e

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -243,7 +243,7 @@ class PanoplyMandrill(panoply.DataSource):
             #zf.close()
             output = StringIO()
             shutil.copyfileobj(zf.open(CSV_FILE_NAME), output, COPY_CHUNK_SIZE)
-            csv_reader = csv.DictReader(output delimiter=',')
+            csv_reader = csv.DictReader(output, delimiter=',')
             self.log('zipfile has been retrieved')
         except Exception, e:
             raise e

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -240,9 +240,10 @@ class PanoplyMandrill(panoply.DataSource):
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
             self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)
-            #zf.close()
-            output = StringIO()
+            # put the extracted file inside the memory StringIO
+            output = StringIO.StringIO()
             shutil.copyfileobj(zf.open(CSV_FILE_NAME), output, COPY_CHUNK_SIZE)
+            zf.close()
             csv_reader = csv.DictReader(output, delimiter=',')
             self.log('zipfile has been retrieved')
         except Exception, e:

--- a/panoply_mandrill/panoply_mandrill.py
+++ b/panoply_mandrill/panoply_mandrill.py
@@ -7,7 +7,7 @@ import shutil
 import zipfile
 import csv
 import os
-import mmap
+import StringIO
 from datetime import datetime
 from functools import partial, wraps
 from itertools import chain
@@ -240,9 +240,10 @@ class PanoplyMandrill(panoply.DataSource):
             shutil.copyfileobj(req, tmp_file, COPY_CHUNK_SIZE)
             self.log('download has finished size:', os.path.getsize(tmp_file.name))
             zf = zipfile.ZipFile(tmp_file)
-            #mapped_file = mmap.mmap(zf.open(CSV_FILE_NAME).fileno(), 0, access=mmap.ACCESS_READ)
             #zf.close()
-            csv_reader = csv.DictReader(zf.open(CSV_FILE_NAME), delimiter=',')
+            output = StringIO()
+            shutil.copyfileobj(zf.open(CSV_FILE_NAME), output, COPY_CHUNK_SIZE)
+            csv_reader = csv.DictReader(output delimiter=',')
             self.log('zipfile has been retrieved')
         except Exception, e:
             raise e

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_mandrill",
-    version="1.0.4",
+    version="1.0.6",
     description="Panoply Data Source for Mandrill API",
     author="Kfir Gez, Oshri Bienhaker",
     author_email="kfir@panoply.io, oshri@panoply.io",


### PR DESCRIPTION
The bug we had may be related to the fact that the python process took more than 1.3gb of ram.
I now iterate over the in-memory file instead of parsing it whole at the start.

It seems like 80mb csv file parsed by the CSV-PARSER is actually around 1gb of ram.