### PR TITLE
Remove the URLs resource

### DIFF
--- a/panoply_mandrill/conf.py
+++ b/panoply_mandrill/conf.py
@@ -6,29 +6,24 @@ metrics = [
         "path": "search_time_series",
         "includeTimeframe": True
     },
-
     {
         "name": "tags",
         "path": "all_time_series"
     },
-
     {
         "name": "senders",
         "path": "time_series",
         "required": "address",
     },
-
     {
         "name": "templates",
         "path": "time_series",
         "required": "name",
     },
-
     {
         "name": "webhooks",
         "path": "list"
     },
-
     {
         "name": "subaccounts",
         "path": "list"

--- a/panoply_mandrill/conf.py
+++ b/panoply_mandrill/conf.py
@@ -19,12 +19,6 @@ metrics = [
     },
 
     {
-        "name": "urls",
-        "path": "time_series",
-        "required": "url",
-    },
-
-    {
         "name": "templates",
         "path": "time_series",
         "required": "name",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-"panoply-python-sdk==1.3.2"
+"panoply-python-sdk==1.6.0"
 "mock==1.0.1"
 "mandrill==1.0.57"
-"requests==2.3.0"
+"requests==2.21.0"

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ setup(
     name="panoply_mandrill",
     version="2.0.0",
     description="Panoply Data Source for Mandrill API",
-    author="Kfir Gez, Oshri Bienhaker",
-    author_email="kfir@panoply.io, oshri@panoply.io",
+    author="Panoply Dev Team",
+    author_email="support@panoply.io",
     url="http://panoply.io",
     package_dir={"panoply": ""},
     install_requires=[
-        "requests==2.3.0",
-        "panoply-python-sdk",
+        "requests==2.21.0",
+        "panoply-python-sdk==1.6.0",
         "csvsort==1.3",
         "mandrill==1.0.57"
     ],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_mandrill",
-    version="1.0.8",
+    version="2.0.0",
     description="Panoply Data Source for Mandrill API",
     author="Kfir Gez, Oshri Bienhaker",
     author_email="kfir@panoply.io, oshri@panoply.io",


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/280843276935180/953332546956093/f)

# Description
Mandrill has started returning the following error when pulling the URLs
resource: `Error: Due to changes to our infrastructure, we no longer
support URL tracking reports in Mandrill.`

The fix: stop calling this resource.